### PR TITLE
Initial version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/@jenkins-cd/js-builder.js
+++ b/@jenkins-cd/js-builder.js
@@ -42,9 +42,17 @@ function install(builder) {
             process.env.JEST_JUNIT_OUTPUT = reportsPath;
         }
 
+        // measure coverage from all js/x files in source paths
+        var collectCoverageFrom = builder.paths.srcPaths.map(function (path) {
+            return path + '/**/*.{js,jsx}';
+        });
+                
+        logInfo('collectCoverageFrom: ' + collectCoverageFrom.join(', '));
+
         return runJest({
             config: {
                 collectCoverage: true,
+                collectCoverageFrom: collectCoverageFrom,
                 testMatch: testMatch,
                 testResultsProcessor: 'jest-junit'
             }

--- a/@jenkins-cd/js-builder.js
+++ b/@jenkins-cd/js-builder.js
@@ -1,0 +1,77 @@
+var gulp = require('gulp');
+var jest = require('gulp-jest').default;
+var minimist = require('minimist');
+var del = require('del');
+
+
+var testMatch = ['**/?(*-)(spec|test).js?(x)'];
+var coveragePath = 'coverage';
+var reportsPath = 'reports/junit.xml';
+
+
+function install(builder) {
+    var logInfo = builder.logger.logInfo;
+    var logError = builder.logger.logError;
+
+    logInfo('installing js-builder-jest into js-builder');
+
+    function runJest(jestOptions) {
+        var options = jestOptions;
+        var argv = minimist(process.argv.slice(2));
+        options.testPathPattern = argv.test || null;
+
+        logInfo('cleaning coverage and reports');
+        del(coveragePath);
+        del(reportsPath);
+
+        return gulp.src('.')
+            .pipe(jest(options))
+            .on('end', function () {
+                logInfo('tests completed successfully!');
+            })
+            .on('error', function () {
+                logError('tests failed or errored!');
+                process.exit(1);
+            });
+    }
+
+    builder.defineTask('test', function () {
+        logInfo('running js-builder-jest:test');
+
+        if (!process.env.JEST_JUNIT_OUTPUT) {
+            process.env.JEST_JUNIT_OUTPUT = reportsPath;
+        }
+
+        return runJest({
+            config: {
+                collectCoverage: true,
+                testMatch: testMatch,
+                testResultsProcessor: 'jest-junit'
+            }
+        });
+    });
+
+    builder.defineTask('test:fast', function () {
+        logInfo('running js-builder-jest:test:fast');
+
+        return runJest({
+            notify: true,
+            forceExit: true,
+            config: {
+                testMatch: testMatch
+            }
+        });
+    });
+
+    builder.defineTask('test:debug', function () {
+        logInfo('running js-builder-jest:test:debug');
+        logInfo('debug support is coming soon.');
+    });
+
+    builder.defineTask('test:watch', function () {
+        logInfo('running js-builder-jest:test:watch');
+        logInfo('watch is not supported. maybe later.');
+    });
+}
+
+exports.install = install;

--- a/@jenkins-cd/js-builder.js
+++ b/@jenkins-cd/js-builder.js
@@ -36,6 +36,8 @@ function install(builder) {
     }
 
     builder.defineTask('test', function () {
+        var collectCoverageFrom;
+
         logInfo('running js-builder-jest:test');
 
         if (!process.env.JEST_JUNIT_OUTPUT) {
@@ -43,10 +45,10 @@ function install(builder) {
         }
 
         // measure coverage from all js/x files in source paths
-        var collectCoverageFrom = builder.paths.srcPaths.map(function (path) {
+        collectCoverageFrom = builder.paths.srcPaths.map(function (path) {
             return path + '/**/*.{js,jsx}';
         });
-                
+
         logInfo('collectCoverageFrom: ' + collectCoverageFrom.join(', '));
 
         return runJest({

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Run your tests with Jenkins JS Builder using the "Jest" test runner.
 
 The default location for tests is the `test` folder.
-The file names need to match the pattern "*-spec.js" or "*-test.js"; the "jsx" extension is also supported.
+The file names need to match the pattern `*-spec.js` or `*-test.js`; the `jsx` extension is also supported.
 The default location can be overridden by calling `builder.tests(<new-path>)`.
 
 ## 'test' Task
@@ -16,10 +16,22 @@ Run the tests and produces test and coverage reports.
 
 You can limit the tests that are run via the `test` parameter. This is a pattern that is passed to Jest's [testMatch](https://facebook.github.io/jest/docs/configuration.html#testmatch-array-string) parameter.
 
+Run a single test.
+
 ```
-jjsbuilder --tasks test -- --test calculator # runs any test with 'calculator' in the name
-jjsbuilder --tasks test -- --test /math/ # run any test inside of a 'math' folder
-jjsbuilder --tasks test -- --test test/src/js/foo/bar/foobar-spec # run a single test
+jjsbuilder --tasks test -- --test test/src/js/foo/bar/foobar-spec
+```
+
+Runs any test with 'calculator' in the path or name.
+
+```
+jjsbuilder --tasks test -- --test calculator
+```
+
+Run any test inside of a 'math' folder.
+
+```
+jjsbuilder --tasks test -- --test /math/
 ```
 
 JUnit test reports are stored in `reports/` and coverage reports in `coverage/`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Jest support for Jenkins JS Builder
+
+Run your tests with Jenkins JS Builder using the "Jest" test runner.
+
+The default location for tests is the `test` folder.
+The file names need to match the pattern "*-spec.js" or "*-test.js"; the "jsx" extension is also supported.
+The default location can be overridden by calling `builder.tests(<new-path>)`.
+
+## 'test' Task
+
+```
+jjsbuilder --tasks test
+```
+
+Run the tests and produces test and coverage reports.
+
+You can limit the tests that are run via the `test` parameter. This is a pattern that is passed to Jest's [testMatch](https://facebook.github.io/jest/docs/configuration.html#testmatch-array-string) parameter.
+
+```
+jjsbuilder --tasks test -- --test calculator # runs any test with 'calculator' in the name
+jjsbuilder --tasks test -- --test /math/ # run any test inside of a 'math' folder
+jjsbuilder --tasks test -- --test test/src/js/foo/bar/foobar-spec # run a single test
+```
+
+JUnit test reports are stored in `reports/` and coverage reports in `coverage/`.
+Note that coverage is only measured for .js and .jsx files in the source directories (default: `src`).
+
+## 'test:fast" Task
+
+```
+jjsbuilder --tasks test:fast
+```
+
+Runs the tests but skips generation of reports and coverage. 
+It also displays an OS notification when tests complete.
+This is good for local development.
+
+## 'test:debug' Task
+
+Coming soon.
+
+## 'test:watch' Task
+
+Coming later.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,5 @@
+//
+// See https://github.com/jenkinsci/js-builder
+//
+var builder = require('@jenkins-cd/js-builder');
+builder.src(['src', '@jenkins-cd']);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder-jest",
-  "version": "0.0.1",
+  "version": "0.0.1-beta-1",
   "description": "Adds support for running tests with Jest via Jenkins js-builder",
   "main": "dist/js/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder-jest",
-  "version": "0.0.1-beta-1",
+  "version": "0.0.1",
   "description": "Adds support for running tests with Jest via Jenkins js-builder",
   "main": "dist/js/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@jenkins-cd/js-builder-jest",
+  "version": "0.0.1",
+  "description": "Adds support for running tests with Jest via Jenkins js-builder",
+  "main": "dist/js/index.js",
+  "scripts": {
+    "build": "jjsbuilder",
+    "test": "jjsbuilder"
+  },
+  "author": "Cliff Meyers <cliff.meyers@gmail.com> (https://github.com/cliffmeyers)",
+  "license": "MIT",
+  "files": [
+    "@jenkins-cd",
+    "LICENSE",
+    "README.md"
+  ],
+  "devDependencies": {
+    "@jenkins-cd/js-builder": "0.0.55",
+    "@jenkins-cd/js-modules": "0.0.9"
+  },
+  "dependencies": {
+    "del": "2.2.2",
+    "gulp-jest": "1.0.0",
+    "jest-cli": "19.0.2",
+    "jest-junit": "1.5.1",
+    "minimist": "1.2.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder-jest",
-  "version": "0.0.1",
+  "version": "0.0.1-SNAPSHOT-1",
   "description": "Adds support for running tests with Jest via Jenkins js-builder",
   "main": "dist/js/index.js",
   "scripts": {


### PR DESCRIPTION
This runs tests via Jest. It currently supports two modes:
- "test" - which runs all tests concurrently and generates test reports, and coverage reports.
- "test:fast" which just runs all tests concurrently, and display an OS notification when done

Developer can limit the tests being run by specifying a pattern using the following syntax:
`npm run test:fast -- --test pipelines # run any tests with "pipelines" in the name
`npm run test:fast -- --test /creation/ # run any tests inside of a "creation" folder

I intend to add support for "test:debug" in a future PR pretty soon. Not sure if I'll have time to add "test:watch" until later on. 